### PR TITLE
Implement basic versioning scaffolding

### DIFF
--- a/operator/api/v1alpha1/ducklakecatalog_types.go
+++ b/operator/api/v1alpha1/ducklakecatalog_types.go
@@ -77,8 +77,9 @@ type BackupPolicySpec struct {
 	// RetentionDays is the number of days to retain backups
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:default=7
-	RetentionDays int `json:"retentionDays,omitempty"`
+        RetentionDays int `json:"retentionDays,omitempty"`
 }
+
 
 // DuckLakeCatalogSpec defines the desired state of DuckLakeCatalog
 type DuckLakeCatalogSpec struct {
@@ -103,9 +104,17 @@ type DuckLakeCatalogSpec struct {
 	// +optional
 	BackupPolicy *BackupPolicySpec `json:"backupPolicy,omitempty"`
 
-	// CatalogPath is the path to the DuckDB catalog file within the PVC
-	// +kubebuilder:default=/catalog/catalog.db
-	CatalogPath string `json:"catalogPath,omitempty"`
+        // CatalogPath is the path to the DuckDB catalog file within the PVC
+        // +kubebuilder:default=/catalog/catalog.db
+        CatalogPath string `json:"catalogPath,omitempty"`
+
+       // RestoreVersion, if set, restores the catalog to a historical version
+       // +optional
+       RestoreVersion string `json:"restoreVersion,omitempty"`
+
+       // Versioning controls automatic metadata snapshotting
+       // +optional
+       Versioning *VersioningSpec `json:"versioning,omitempty"`
 }
 
 // CatalogPhase represents the current phase of the catalog
@@ -139,7 +148,11 @@ type DuckLakeCatalogStatus struct {
 
 	// ObservedGeneration is the last generation that was acted on
 	// +optional
-	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+       ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+       // VersionHistory lists recent catalog versions
+       // +optional
+       VersionHistory []VersionEntry `json:"versionHistory,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operator/api/v1alpha1/ducklaketable_types.go
+++ b/operator/api/v1alpha1/ducklaketable_types.go
@@ -229,7 +229,15 @@ type DuckLakeTableSpec struct {
 
 	// MaterializeTo configures optional view materialization
 	// +optional
-	MaterializeTo *MaterializeToSpec `json:"materializeTo,omitempty"`
+       MaterializeTo *MaterializeToSpec `json:"materializeTo,omitempty"`
+
+       // RestoreVersion, if set, restores the table to a historical version
+       // +optional
+       RestoreVersion string `json:"restoreVersion,omitempty"`
+
+       // Versioning controls automatic metadata snapshotting
+       // +optional
+       Versioning *VersioningSpec `json:"versioning,omitempty"`
 }
 
 // DuckLakeTableStatus defines the observed state of DuckLakeTable
@@ -260,7 +268,11 @@ type DuckLakeTableStatus struct {
 
 	// Materialization holds information about the last materialization run
 	// +optional
-	Materialization *MaterializationStatus `json:"materialization,omitempty"`
+       Materialization *MaterializationStatus `json:"materialization,omitempty"`
+
+       // VersionHistory lists recent table versions
+       // +optional
+       VersionHistory []VersionEntry `json:"versionHistory,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/operator/api/v1alpha1/versioning_types.go
+++ b/operator/api/v1alpha1/versioning_types.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// VersioningSpec controls automatic snapshotting of metadata
+// for catalogs and tables
+// +kubebuilder:object:generate=true
+// +kubebuilder:resource:scope=Namespaced
+type VersioningSpec struct {
+    // Enabled toggles versioning
+    // +kubebuilder:default=false
+    Enabled bool `json:"enabled"`
+
+    // Retention defines how long to keep versions
+    // +optional
+    Retention metav1.Duration `json:"retention,omitempty"`
+
+    // Strategy determines versioning backend implementation
+    // +kubebuilder:default=snapshot
+    // +optional
+    Strategy string `json:"strategy,omitempty"`
+}
+
+// VersionEntry represents a stored resource version
+type VersionEntry struct {
+    // ID is the version identifier
+    ID string `json:"id"`
+    // Timestamp records when the snapshot was taken
+    Timestamp metav1.Time `json:"timestamp"`
+}

--- a/operator/pkg/versioning/snapshot.go
+++ b/operator/pkg/versioning/snapshot.go
@@ -1,0 +1,108 @@
+package versioning
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "time"
+
+    ducklakev1alpha1 "github.com/TFMV/featherman/operator/api/v1alpha1"
+    "github.com/TFMV/featherman/operator/internal/storage"
+)
+
+// Writer persists and retrieves resource snapshots.
+type Writer struct {
+    Store storage.ObjectStore
+}
+
+// snapshotRecord is the payload written to object storage.
+type snapshotRecord struct {
+    Timestamp time.Time       `json:"timestamp"`
+    Spec      json.RawMessage `json:"spec"`
+    Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// SaveCatalog stores a snapshot of the catalog spec and returns the version id.
+func (w *Writer) SaveCatalog(ctx context.Context, c *ducklakev1alpha1.DuckLakeCatalog, annotations map[string]string) (string, error) {
+    if w == nil || w.Store == nil {
+        return "", fmt.Errorf("nil writer or store")
+    }
+    version := fmt.Sprintf("v%s", time.Now().UTC().Format("20060102-150405"))
+    payload, err := json.Marshal(snapshotRecord{
+        Timestamp: time.Now().UTC(),
+        Spec:      mustJSON(c.Spec),
+        Annotations: annotations,
+    })
+    if err != nil {
+        return "", err
+    }
+    key := fmt.Sprintf("meta/%s/%s.json", version, c.Name)
+    return version, w.Store.PutObject(ctx, c.Spec.ObjectStore.Bucket, key, payload)
+}
+
+// LoadCatalog retrieves a catalog spec for the given version.
+func (w *Writer) LoadCatalog(ctx context.Context, c *ducklakev1alpha1.DuckLakeCatalog, version string) (*ducklakev1alpha1.DuckLakeCatalogSpec, error) {
+    if w == nil || w.Store == nil {
+        return nil, fmt.Errorf("nil writer or store")
+    }
+    key := fmt.Sprintf("meta/%s/%s.json", version, c.Name)
+    data, err := w.Store.GetObject(ctx, c.Spec.ObjectStore.Bucket, key)
+    if err != nil {
+        return nil, err
+    }
+    var rec snapshotRecord
+    if err := json.Unmarshal(data, &rec); err != nil {
+        return nil, err
+    }
+    var spec ducklakev1alpha1.DuckLakeCatalogSpec
+    if err := json.Unmarshal(rec.Spec, &spec); err != nil {
+        return nil, err
+    }
+    return &spec, nil
+}
+
+// SaveTable stores a snapshot of the table spec and returns the version id.
+func (w *Writer) SaveTable(ctx context.Context, t *ducklakev1alpha1.DuckLakeTable, bucket string, annotations map[string]string) (string, error) {
+    if w == nil || w.Store == nil {
+        return "", fmt.Errorf("nil writer or store")
+    }
+    version := fmt.Sprintf("v%s", time.Now().UTC().Format("20060102-150405"))
+    payload, err := json.Marshal(snapshotRecord{
+        Timestamp: time.Now().UTC(),
+        Spec:      mustJSON(t.Spec),
+        Annotations: annotations,
+    })
+    if err != nil {
+        return "", err
+    }
+    key := fmt.Sprintf("meta/%s/%s.json", version, t.Name)
+    return version, w.Store.PutObject(ctx, bucket, key, payload)
+}
+
+// LoadTable retrieves a table spec for the given version.
+func (w *Writer) LoadTable(ctx context.Context, t *ducklakev1alpha1.DuckLakeTable, bucket, version string) (*ducklakev1alpha1.DuckLakeTableSpec, error) {
+    if w == nil || w.Store == nil {
+        return nil, fmt.Errorf("nil writer or store")
+    }
+    key := fmt.Sprintf("meta/%s/%s.json", version, t.Name)
+    data, err := w.Store.GetObject(ctx, bucket, key)
+    if err != nil {
+        return nil, err
+    }
+    var rec snapshotRecord
+    if err := json.Unmarshal(data, &rec); err != nil {
+        return nil, err
+    }
+    var spec ducklakev1alpha1.DuckLakeTableSpec
+    if err := json.Unmarshal(rec.Spec, &spec); err != nil {
+        return nil, err
+    }
+    return &spec, nil
+}
+
+func mustJSON(in interface{}) json.RawMessage {
+    b, _ := json.Marshal(in)
+    return json.RawMessage(b)
+}
+
+*** End of File

--- a/operator/pkg/versioning/snapshot_test.go
+++ b/operator/pkg/versioning/snapshot_test.go
@@ -1,0 +1,48 @@
+package versioning
+
+import (
+    "context"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/TFMV/featherman/operator/internal/storage"
+
+    ducklakev1alpha1 "github.com/TFMV/featherman/operator/api/v1alpha1"
+)
+
+// memoryStore is a simple in-memory ObjectStore for tests
+type memoryStore struct {
+   objects map[string][]byte
+}
+
+ func newMemoryStore() *memoryStore { return &memoryStore{objects: map[string][]byte{}} }
+
+ func (m *memoryStore) ListBuckets(ctx context.Context) ([]string, error) { return []string{"b"}, nil }
+ func (m *memoryStore) CreateBucket(ctx context.Context, bucket string) error { return nil }
+ func (m *memoryStore) DeleteBucket(ctx context.Context, bucket string) error { return nil }
+ func (m *memoryStore) ListObjects(ctx context.Context, bucket, prefix string) ([]string, error) { return nil, nil }
+ func (m *memoryStore) GetObject(ctx context.Context, bucket, key string) ([]byte, error) {
+    return m.objects[bucket+"/"+key], nil
+ }
+ func (m *memoryStore) PutObject(ctx context.Context, bucket, key string, data []byte) error {
+    m.objects[bucket+"/"+key] = data
+    return nil
+ }
+func (m *memoryStore) DeleteObject(ctx context.Context, bucket, key string) error { delete(m.objects, bucket+"/"+key); return nil }
+
+var _ storage.ObjectStore = &memoryStore{}
+
+ func TestCatalogSnapshotRoundTrip(t *testing.T) {
+    store := newMemoryStore()
+    writer := &Writer{Store: store}
+
+    c := &ducklakev1alpha1.DuckLakeCatalog{Spec: ducklakev1alpha1.DuckLakeCatalogSpec{ObjectStore: ducklakev1alpha1.ObjectStoreSpec{Bucket: "b"}}}
+
+    ver, err := writer.SaveCatalog(context.Background(), c, nil)
+    assert.NoError(t, err)
+    assert.NotEmpty(t, ver)
+
+    spec, err := writer.LoadCatalog(context.Background(), c, ver)
+    assert.NoError(t, err)
+    assert.Equal(t, c.Spec.ObjectStore.Bucket, spec.ObjectStore.Bucket)
+ }


### PR DESCRIPTION
## Summary
- add versioning and restore fields to catalog and table CRDs
- create common `VersioningSpec` and `VersionEntry` types
- start a versioning package with snapshot writer and tests

## Testing
- `make generate` *(fails: cannot execute controller-gen)*
- `make test` *(fails: cannot execute controller-gen)*

------
https://chatgpt.com/codex/tasks/task_e_68553e759d60832e8e4c75245c293b44