### PR TITLE
Add feathermanctl CLI skeleton

### DIFF
--- a/feathermanctl/cmd/deploy.go
+++ b/feathermanctl/cmd/deploy.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy [manifest]",
+	Short: "Deploy a catalog or table manifest",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		color.Green("Deploying %s", args[0])
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deployCmd)
+}

--- a/feathermanctl/cmd/init.go
+++ b/feathermanctl/cmd/init.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a Featherman environment",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ns := viper.GetString("namespace")
+		withMinio, _ := cmd.Flags().GetBool("with-minio")
+		color.Green("Initializing namespace %s (minio=%v)", ns, withMinio)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().Bool("with-minio", false, "Install MinIO")
+	viper.BindPFlag("with-minio", initCmd.Flags().Lookup("with-minio"))
+}

--- a/feathermanctl/cmd/materialize.go
+++ b/feathermanctl/cmd/materialize.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var materializeCmd = &cobra.Command{
+	Use:   "materialize [manifest]",
+	Short: "Materialize a view or table",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dest := viper.GetString("to")
+		color.Yellow("Materializing %s to %s", args[0], dest)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(materializeCmd)
+	materializeCmd.Flags().String("to", "", "Destination path")
+	viper.BindPFlag("to", materializeCmd.Flags().Lookup("to"))
+}

--- a/feathermanctl/cmd/query.go
+++ b/feathermanctl/cmd/query.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var queryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Run an ad-hoc SQL query",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sql := viper.GetString("sql")
+		catalog := viper.GetString("catalog")
+		if sql == "" || catalog == "" {
+			return fmt.Errorf("sql and catalog are required")
+		}
+		color.Green("Querying catalog %s: %s", catalog, sql)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(queryCmd)
+	queryCmd.Flags().String("sql", "", "SQL statement to run")
+	queryCmd.Flags().String("catalog", "", "Catalog name")
+	queryCmd.Flags().StringP("output", "o", "table", "Output format (table,json,csv,arrow)")
+	viper.BindPFlag("sql", queryCmd.Flags().Lookup("sql"))
+	viper.BindPFlag("catalog", queryCmd.Flags().Lookup("catalog"))
+	viper.BindPFlag("output", queryCmd.Flags().Lookup("output"))
+}

--- a/feathermanctl/cmd/root.go
+++ b/feathermanctl/cmd/root.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "feathermanctl",
+	Short: "Command line interface for Featherman",
+	Run: func(cmd *cobra.Command, args []string) {
+		_ = cmd.Help()
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		color.Red("%v", err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.featherman/config.yaml)")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "default", "Kubernetes namespace")
+	viper.BindPFlag("namespace", rootCmd.PersistentFlags().Lookup("namespace"))
+}
+
+func initConfig() {
+	if cfgFile != "" {
+		viper.SetConfigFile(cfgFile)
+	} else {
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+		viper.AddConfigPath(home + "/.featherman")
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("config")
+	}
+
+	viper.AutomaticEnv()
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config", viper.ConfigFileUsed())
+	}
+}

--- a/feathermanctl/cmd/status.go
+++ b/feathermanctl/cmd/status.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show status of lake resources",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		catalog := viper.GetString("catalog")
+		table := viper.GetString("table")
+		color.Cyan("Status for catalog %s table %s", catalog, table)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+	statusCmd.Flags().String("catalog", "", "Catalog name")
+	statusCmd.Flags().String("table", "", "Table name")
+	viper.BindPFlag("catalog", statusCmd.Flags().Lookup("catalog"))
+	viper.BindPFlag("table", statusCmd.Flags().Lookup("table"))
+}

--- a/feathermanctl/go.mod
+++ b/feathermanctl/go.mod
@@ -1,0 +1,3 @@
+module github.com/TFMV/featherman/feathermanctl
+
+go 1.23.8

--- a/feathermanctl/main.go
+++ b/feathermanctl/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/TFMV/featherman/feathermanctl/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary
- scaffold a new `feathermanctl` module using Cobra and Viper
- implement `query`, `status`, `materialize`, `deploy`, and `init` commands
- set up configuration handling and command execution

## Testing
- `gofmt -w feathermanctl/cmd/*.go feathermanctl/main.go`
- `go vet ./...` *(fails: no required module provides package github.com/fatih/color)*
- `go test ./...` *(fails: no required module provides package github.com/fatih/color)*
- `go mod tidy` *(fails to download modules: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685542306f78832e848ed4c2ebcdf60f