### PR TITLE
Add pool hardening configuration

### DIFF
--- a/operator/api/v1alpha1/ducklakepool_types.go
+++ b/operator/api/v1alpha1/ducklakepool_types.go
@@ -36,6 +36,17 @@ type DuckLakePoolSpec struct {
 
 	// Metrics configures metrics exposure
 	Metrics MetricsConfig `json:"metrics,omitempty"`
+
+	// MaxQueryDuration limits how long a query may run
+	// +kubebuilder:default="60s"
+	MaxQueryDuration metav1.Duration `json:"maxQueryDuration,omitempty"`
+
+	// MaxRetries defines how many times to retry failed queries
+	// +kubebuilder:default=3
+	MaxRetries int32 `json:"maxRetries,omitempty"`
+
+	// Queue configures request queueing
+	Queue QueueConfig `json:"queue,omitempty"`
 }
 
 // PodTemplate defines the template for creating warm pods
@@ -119,6 +130,21 @@ type MetricsConfig struct {
 	// Port is the port to expose metrics on
 	// +kubebuilder:default=9090
 	Port int32 `json:"port,omitempty"`
+}
+
+// QueueConfig configures request queueing
+type QueueConfig struct {
+	// MaxLength is the maximum number of queued requests
+	// +kubebuilder:default=100
+	MaxLength int32 `json:"maxLength,omitempty"`
+
+	// MaxWaitTime is the maximum time a request may wait in the queue
+	// +kubebuilder:default="30s"
+	MaxWaitTime metav1.Duration `json:"maxWaitTime,omitempty"`
+
+	// Policy sets the queue policy (fifo or weighted)
+	// +kubebuilder:default="fifo"
+	Policy string `json:"policy,omitempty"`
 }
 
 // PodState represents the state of a warm pod

--- a/operator/internal/controller/ducklakepool_controller.go
+++ b/operator/internal/controller/ducklakepool_controller.go
@@ -125,7 +125,7 @@ func (r *DuckLakePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !exists {
 		// Create new pool manager
-		mgr = pool.NewManager(r.Client, r.K8sClient, r.Scheme, duckLakePool, duckLakePool.Namespace, r.Config)
+		mgr = pool.NewManager(r.Client, r.K8sClient, r.Scheme, duckLakePool, duckLakePool.Namespace, r.Config, r.Recorder)
 		r.poolManagers[managerKey] = mgr
 
 		// Start the manager in a goroutine

--- a/operator/internal/pool/executor.go
+++ b/operator/internal/pool/executor.go
@@ -14,6 +14,10 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/TFMV/featherman/operator/internal/logger"
+	"github.com/TFMV/featherman/operator/internal/metrics"
+	"github.com/TFMV/featherman/operator/internal/retry"
 )
 
 // Executor executes SQL queries on warm pods
@@ -34,6 +38,11 @@ func NewExecutor(k8sClient kubernetes.Interface, config *rest.Config, logger *ze
 
 // ExecuteQuery executes a SQL query on a warm pod
 func (e *Executor) ExecuteQuery(ctx context.Context, pod *WarmPod, sql string, timeout time.Duration) (string, error) {
+	if e.logger == nil {
+		l := logger.FromContext(ctx)
+		e.logger = &l
+	}
+
 	startTime := time.Now()
 	defer func() {
 		e.logger.Debug().

--- a/operator/internal/pool/manager_test.go
+++ b/operator/internal/pool/manager_test.go
@@ -105,6 +105,7 @@ var _ = Describe("Pool Manager", func() {
 				duckPool,
 				"default",
 				&rest.Config{},
+				nil,
 			)
 
 			// Request a pod (should fail as no pods are available)
@@ -148,6 +149,7 @@ var _ = Describe("Pool Manager", func() {
 				duckPool,
 				"default",
 				&rest.Config{},
+				nil,
 			)
 
 			status := manager.GetPoolStatus()
@@ -168,6 +170,7 @@ var _ = Describe("Pool Manager", func() {
 				duckPool,
 				"default",
 				&rest.Config{},
+				nil,
 			)
 
 			err := manager.Shutdown(ctx)


### PR DESCRIPTION
## Summary
- add queue and retry fields to `DuckLakePool` CRD
- expose new pool hardening Prometheus metrics
- implement retry and timeout helper in warm pod manager
- connect pool manager creation to controller event recorder

## Testing
- `go test ./...` *(fails: Forbidden download)*

------
https://chatgpt.com/codex/tasks/task_e_685543c723ac832eb698997296a4c2ae